### PR TITLE
config default nulling fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loom_version=1.15-SNAPSHOT
 
 minecraft_version_compatible=~26.1
 
-mod_version=2.9.0+26.1
+mod_version=2.9.1+26.1
 maven_group=net.lugo.lightoverlay
 archives_base_name=light-overlay
 

--- a/src/main/java/net/lugo/lightoverlay/config/ModConfig.java
+++ b/src/main/java/net/lugo/lightoverlay/config/ModConfig.java
@@ -19,18 +19,38 @@ import java.awt.*;
 
 
 public class ModConfig {
-    @SerialEntry
-    public static int lightLevelThreshold = 1;
+    private static final class Defaults {
+        static final int LIGHT_LEVEL_THRESHOLD = 1;
+        static final int LIGHT_LEVEL_THRESHOLD_NETHER = 12;
+        static final int LIGHT_LEVEL_THRESHOLD_END = 1;
+        static final int LIGHT_LEVEL_THRESHOLD_FARMLAND = 9;
+        static final int CHUNK_SCAN_RANGE = 4;
+        static final int CHUNK_SCAN_RANGE_VERTICAL = 25;
+        static final OverlayHandler.Mode RENDERER_MODE = OverlayHandler.Mode.CROSS;
+        static final boolean HIDE_GREEN = false;
+        static final boolean HIDE_TRANSPARENT = true;
+        static final boolean HIDE_WATER = true;
+        static final boolean SHOW_SPECIAL_SPAWNING_CONDITION_BLOCKS = false;
+        static final boolean SHOW_ON_FARMLAND = false;
+        static final boolean SHOW_WHEN_PAUSED = true;
+        static final boolean ENABLE_IRIS_FLICKER_FIX = true;
+        static final int NEARBY_CHECK_DISTANCE_SQUARED = 16 * 16;
+        static final Color VALID_COLOR = new Color(0, 255, 0, 255);
+        static final Color INVALID_COLOR = new Color(255, 0, 0, 255);
+        static final int MAX_COMPUTATIONS_PER_TICK = 32;
+    }
 
     @SerialEntry
-    public static int lightLevelThresholdNether = 12;
+    public static int lightLevelThreshold = Defaults.LIGHT_LEVEL_THRESHOLD;
 
     @SerialEntry
-    public static int lightLevelThresholdEnd = 1;
+    public static int lightLevelThresholdNether = Defaults.LIGHT_LEVEL_THRESHOLD_NETHER;
 
     @SerialEntry
-    public static int lightLevelThresholdFarmland = 9;
+    public static int lightLevelThresholdEnd = Defaults.LIGHT_LEVEL_THRESHOLD_END;
 
+    @SerialEntry
+    public static int lightLevelThresholdFarmland = Defaults.LIGHT_LEVEL_THRESHOLD_FARMLAND;
     public static int lightLevelThresholdForDimension(ClientLevel level) {
         if (Level.NETHER.equals(level.dimension())) {
             return lightLevelThresholdNether;
@@ -42,49 +62,49 @@ public class ModConfig {
     }
 
     @SerialEntry
-    public static int chunkScanRange = 4;
+    public static int chunkScanRange = Defaults.CHUNK_SCAN_RANGE;
 
     @SerialEntry
-    public static int chunkScanRangeVertical = 25;
+    public static int chunkScanRangeVertical = Defaults.CHUNK_SCAN_RANGE_VERTICAL;
     public static boolean isChunkScanRangeVerticalInfinite(int value) {
         return value > 24;
     }
 
     @SerialEntry
-    public static OverlayHandler.Mode rendererMode = OverlayHandler.Mode.CROSS;
+    public static OverlayHandler.Mode rendererMode = Defaults.RENDERER_MODE;
 
     @SerialEntry
-    public static boolean hideGreen = false;
+    public static boolean hideGreen = Defaults.HIDE_GREEN;
 
     @SerialEntry
-    public static boolean hideTransparent = true;
+    public static boolean hideTransparent = Defaults.HIDE_TRANSPARENT;
 
     @SerialEntry
-    public static boolean hideWater = true;
+    public static boolean hideWater = Defaults.HIDE_WATER;
 
     @SerialEntry
-    public static boolean showSpecialSpawningConditionBlocks = false;
+    public static boolean showSpecialSpawningConditionBlocks = Defaults.SHOW_SPECIAL_SPAWNING_CONDITION_BLOCKS;
 
     @SerialEntry
-    public static boolean showOnFarmland = false;
+    public static boolean showOnFarmland = Defaults.SHOW_ON_FARMLAND;
 
     @SerialEntry
-    public static boolean showWhenPaused = true;
+    public static boolean showWhenPaused = Defaults.SHOW_WHEN_PAUSED;
 
     @SerialEntry
-    public static boolean enableIrisFlickerFix = true;
+    public static Integer nearbyCheckDistanceSquared = Defaults.NEARBY_CHECK_DISTANCE_SQUARED;
 
     @SerialEntry
-    public static Integer nearbyCheckDistanceSquared = 16 * 16;
+    public static Color validColor = Defaults.VALID_COLOR;
 
     @SerialEntry
-    public static Color validColor = new Color(0, 255, 0, 255);
+    public static Color invalidColor = Defaults.INVALID_COLOR;
 
     @SerialEntry
-    public static Color invalidColor = new Color(255, 0, 0, 255);
+    public static int maxComputationsPerTick = Defaults.MAX_COMPUTATIONS_PER_TICK;
 
     @SerialEntry
-    public static int maxComputationsPerTick = 32;
+    public static boolean enableIrisFlickerFix = Defaults.ENABLE_IRIS_FLICKER_FIX;
 
     public static Screen makeScreen(Screen parent) {
         return YetAnotherConfigLib.createBuilder()
@@ -97,7 +117,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.chunk_scan_range.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.chunk_scan_range.description")))
                                         .binding(
-                                                chunkScanRange,
+                                                Defaults.CHUNK_SCAN_RANGE,
                                                 () -> chunkScanRange,
                                                 newVal -> {
                                                     chunkScanRange = newVal;
@@ -111,7 +131,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.scan_range_vertical.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.scan_range_vertical.description")))
                                         .binding(
-                                                chunkScanRangeVertical,
+                                                Defaults.CHUNK_SCAN_RANGE_VERTICAL,
                                                 () -> chunkScanRangeVertical,
                                                 newVal -> {
                                                     chunkScanRangeVertical = newVal;
@@ -126,7 +146,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.overlay_mode.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.overlay_mode.description")))
                                         .binding(
-                                                rendererMode,
+                                                Defaults.RENDERER_MODE,
                                                 () -> rendererMode,
                                                 newVal -> {
                                                     rendererMode = newVal;
@@ -143,7 +163,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold.description")))
                                         .binding(
-                                                lightLevelThreshold,
+                                                Defaults.LIGHT_LEVEL_THRESHOLD,
                                                 () -> lightLevelThreshold,
                                                 newVal -> {
                                                     lightLevelThreshold = newVal;
@@ -157,7 +177,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold_nether.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold_nether.description")))
                                         .binding(
-                                                lightLevelThresholdNether,
+                                                Defaults.LIGHT_LEVEL_THRESHOLD_NETHER,
                                                 () -> lightLevelThresholdNether,
                                                 newVal -> {
                                                     lightLevelThresholdNether = newVal;
@@ -171,7 +191,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold_end.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold_end.description")))
                                         .binding(
-                                                lightLevelThresholdEnd,
+                                                Defaults.LIGHT_LEVEL_THRESHOLD_END,
                                                 () -> lightLevelThresholdEnd,
                                                 newVal -> {
                                                     lightLevelThresholdEnd = newVal;
@@ -185,7 +205,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold_farmland.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold_farmland.description")))
                                         .binding(
-                                                lightLevelThresholdFarmland,
+                                                Defaults.LIGHT_LEVEL_THRESHOLD_FARMLAND,
                                                 () -> lightLevelThresholdFarmland,
                                                 newVal -> {
                                                     lightLevelThresholdFarmland = newVal;
@@ -202,7 +222,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.hide_green.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.hide_green.description")))
                                         .binding(
-                                                hideGreen,
+                                                Defaults.HIDE_GREEN,
                                                 () -> hideGreen,
                                                 newVal -> {
                                                     hideGreen = newVal;
@@ -214,7 +234,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.hide_transparent.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.hide_transparent.description")))
                                         .binding(
-                                                hideTransparent,
+                                                Defaults.HIDE_TRANSPARENT,
                                                 () -> hideTransparent,
                                                 newVal -> {
                                                     hideTransparent = newVal;
@@ -226,7 +246,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.hide_water.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.hide_water.description")))
                                         .binding(
-                                                hideWater,
+                                                Defaults.HIDE_WATER,
                                                 () -> hideWater,
                                                 newVal -> {
                                                     hideWater = newVal;
@@ -238,7 +258,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.show_special_spawning_condition_blocks.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.show_special_spawning_condition_blocks.description")))
                                         .binding(
-                                                showSpecialSpawningConditionBlocks,
+                                                Defaults.SHOW_SPECIAL_SPAWNING_CONDITION_BLOCKS,
                                                 () -> showSpecialSpawningConditionBlocks,
                                                 newVal -> {
                                                     showSpecialSpawningConditionBlocks = newVal;
@@ -250,7 +270,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.show_on_farmland.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.show_on_farmland.description")))
                                         .binding(
-                                                showOnFarmland,
+                                                Defaults.SHOW_ON_FARMLAND,
                                                 () -> showOnFarmland,
                                                 newVal -> {
                                                     showOnFarmland = newVal;
@@ -265,7 +285,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.valid_color.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.valid_color.description")))
                                         .binding(
-                                                validColor,
+                                                Defaults.VALID_COLOR,
                                                 () -> validColor,
                                                 newVal -> {
                                                     validColor = newVal;
@@ -278,7 +298,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.invalid_color.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.invalid_color.description")))
                                         .binding(
-                                                invalidColor,
+                                                Defaults.INVALID_COLOR,
                                                 () -> invalidColor,
                                                 newVal -> {
                                                     invalidColor = newVal;
@@ -294,8 +314,8 @@ public class ModConfig {
                         .option(Option.<Boolean>createBuilder()
                                 .name(Component.translatable("text.light-overlay.config.option.show_when_paused.name"))
                                 .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.show_when_paused.description")))
-                                        .binding(
-                                        showWhenPaused,
+                                .binding(
+                                        Defaults.SHOW_WHEN_PAUSED,
                                         () -> showWhenPaused,
                                         newVal -> showWhenPaused = newVal)
                                 .controller(TickBoxControllerBuilder::create)
@@ -304,7 +324,7 @@ public class ModConfig {
                                 .name(Component.translatable("text.light-overlay.config.option.max_computations_per_tick.name"))
                                 .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.max_computations_per_tick.description")))
                                 .binding(
-                                        maxComputationsPerTick,
+                                        Defaults.MAX_COMPUTATIONS_PER_TICK,
                                         () -> maxComputationsPerTick,
                                         newVal -> {
                                             maxComputationsPerTick = newVal;
@@ -319,7 +339,7 @@ public class ModConfig {
                                 .option(Option.<Boolean>createBuilder()
                                         .name(Component.translatable("text.light-overlay.config.option.enable_iris_flicker_fix.name"))
                                         .binding(
-                                                enableIrisFlickerFix,
+                                                Defaults.ENABLE_IRIS_FLICKER_FIX,
                                                 () -> enableIrisFlickerFix,
                                                 newVal -> enableIrisFlickerFix = newVal)
                                         .controller(TickBoxControllerBuilder::create)
@@ -327,7 +347,7 @@ public class ModConfig {
                                 .option(Option.<Integer>createBuilder()
                                         .name(Component.translatable("text.light-overlay.config.option.nearby_check_distance.name"))
                                         .binding(
-                                                nearbyCheckDistanceSquared,
+                                                Defaults.NEARBY_CHECK_DISTANCE_SQUARED,
                                                 () -> nearbyCheckDistanceSquared,
                                                 newVal -> nearbyCheckDistanceSquared = newVal)
                                         .controller(IntegerFieldControllerBuilder::create)

--- a/src/main/java/net/lugo/lightoverlay/config/ModConfig.java
+++ b/src/main/java/net/lugo/lightoverlay/config/ModConfig.java
@@ -20,13 +20,16 @@ import java.awt.*;
 
 public class ModConfig {
     @SerialEntry
-    public static int lightLevelThreshold;
+    public static int lightLevelThreshold = 1;
+
     @SerialEntry
-    public static int lightLevelThresholdNether;
+    public static int lightLevelThresholdNether = 12;
+
     @SerialEntry
-    public static int lightLevelThresholdEnd;
+    public static int lightLevelThresholdEnd = 1;
+
     @SerialEntry
-    public static int lightLevelThresholdFarmland;
+    public static int lightLevelThresholdFarmland = 9;
 
     public static int lightLevelThresholdForDimension(ClientLevel level) {
         if (Level.NETHER.equals(level.dimension())) {
@@ -39,9 +42,10 @@ public class ModConfig {
     }
 
     @SerialEntry
-    public static int chunkScanRange;
+    public static int chunkScanRange = 4;
+
     @SerialEntry
-    public static int chunkScanRangeVertical;
+    public static int chunkScanRangeVertical = 25;
     public static boolean isChunkScanRangeVerticalInfinite(int value) {
         return value > 24;
     }
@@ -50,28 +54,37 @@ public class ModConfig {
     public static OverlayHandler.Mode rendererMode = OverlayHandler.Mode.CROSS;
 
     @SerialEntry
-    public static boolean hideGreen;
-    @SerialEntry
-    public static boolean hideTransparent;
-    @SerialEntry
-    public static boolean hideWater;
-    @SerialEntry
-    public static boolean showSpecialSpawningConditionBlocks;
-    @SerialEntry
-    public static boolean showOnFarmland;
-    @SerialEntry
-    public static boolean showWhenPaused;
-    @SerialEntry
-    public static boolean enableIrisFlickerFix;
-    @SerialEntry
-    public static Integer nearbyCheckDistanceSquared;
+    public static boolean hideGreen = false;
 
     @SerialEntry
-    public static Color validColor;
+    public static boolean hideTransparent = true;
+
     @SerialEntry
-    public static Color invalidColor;
+    public static boolean hideWater = true;
+
     @SerialEntry
-    public static int maxComputationsPerTick;
+    public static boolean showSpecialSpawningConditionBlocks = false;
+
+    @SerialEntry
+    public static boolean showOnFarmland = false;
+
+    @SerialEntry
+    public static boolean showWhenPaused = true;
+
+    @SerialEntry
+    public static boolean enableIrisFlickerFix = true;
+
+    @SerialEntry
+    public static Integer nearbyCheckDistanceSquared = 16 * 16;
+
+    @SerialEntry
+    public static Color validColor = new Color(0, 255, 0, 255);
+
+    @SerialEntry
+    public static Color invalidColor = new Color(255, 0, 0, 255);
+
+    @SerialEntry
+    public static int maxComputationsPerTick = 32;
 
     public static Screen makeScreen(Screen parent) {
         return YetAnotherConfigLib.createBuilder()
@@ -84,7 +97,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.chunk_scan_range.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.chunk_scan_range.description")))
                                         .binding(
-                                                4,
+                                                chunkScanRange,
                                                 () -> chunkScanRange,
                                                 newVal -> {
                                                     chunkScanRange = newVal;
@@ -98,7 +111,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.scan_range_vertical.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.scan_range_vertical.description")))
                                         .binding(
-                                                25,
+                                                chunkScanRangeVertical,
                                                 () -> chunkScanRangeVertical,
                                                 newVal -> {
                                                     chunkScanRangeVertical = newVal;
@@ -113,7 +126,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.overlay_mode.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.overlay_mode.description")))
                                         .binding(
-                                                OverlayHandler.Mode.CROSS,
+                                                rendererMode,
                                                 () -> rendererMode,
                                                 newVal -> {
                                                     rendererMode = newVal;
@@ -130,7 +143,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold.description")))
                                         .binding(
-                                                1,
+                                                lightLevelThreshold,
                                                 () -> lightLevelThreshold,
                                                 newVal -> {
                                                     lightLevelThreshold = newVal;
@@ -144,7 +157,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold_nether.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold_nether.description")))
                                         .binding(
-                                                12,
+                                                lightLevelThresholdNether,
                                                 () -> lightLevelThresholdNether,
                                                 newVal -> {
                                                     lightLevelThresholdNether = newVal;
@@ -158,7 +171,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold_end.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold_end.description")))
                                         .binding(
-                                                1,
+                                                lightLevelThresholdEnd,
                                                 () -> lightLevelThresholdEnd,
                                                 newVal -> {
                                                     lightLevelThresholdEnd = newVal;
@@ -172,7 +185,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.light_level_threshold_farmland.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.light_level_threshold_farmland.description")))
                                         .binding(
-                                                9,
+                                                lightLevelThresholdFarmland,
                                                 () -> lightLevelThresholdFarmland,
                                                 newVal -> {
                                                     lightLevelThresholdFarmland = newVal;
@@ -189,7 +202,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.hide_green.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.hide_green.description")))
                                         .binding(
-                                                false,
+                                                hideGreen,
                                                 () -> hideGreen,
                                                 newVal -> {
                                                     hideGreen = newVal;
@@ -201,7 +214,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.hide_transparent.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.hide_transparent.description")))
                                         .binding(
-                                                true,
+                                                hideTransparent,
                                                 () -> hideTransparent,
                                                 newVal -> {
                                                     hideTransparent = newVal;
@@ -213,7 +226,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.hide_water.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.hide_water.description")))
                                         .binding(
-                                                true,
+                                                hideWater,
                                                 () -> hideWater,
                                                 newVal -> {
                                                     hideWater = newVal;
@@ -225,7 +238,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.show_special_spawning_condition_blocks.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.show_special_spawning_condition_blocks.description")))
                                         .binding(
-                                                false,
+                                                showSpecialSpawningConditionBlocks,
                                                 () -> showSpecialSpawningConditionBlocks,
                                                 newVal -> {
                                                     showSpecialSpawningConditionBlocks = newVal;
@@ -237,7 +250,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.show_on_farmland.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.show_on_farmland.description")))
                                         .binding(
-                                                false,
+                                                showOnFarmland,
                                                 () -> showOnFarmland,
                                                 newVal -> {
                                                     showOnFarmland = newVal;
@@ -252,7 +265,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.valid_color.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.valid_color.description")))
                                         .binding(
-                                                new Color(0, 255, 0, 255),
+                                                validColor,
                                                 () -> validColor,
                                                 newVal -> {
                                                     validColor = newVal;
@@ -265,7 +278,7 @@ public class ModConfig {
                                         .name(Component.translatable("text.light-overlay.config.option.invalid_color.name"))
                                         .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.invalid_color.description")))
                                         .binding(
-                                                new Color(255, 0, 0, 255),
+                                                invalidColor,
                                                 () -> invalidColor,
                                                 newVal -> {
                                                     invalidColor = newVal;
@@ -281,17 +294,17 @@ public class ModConfig {
                         .option(Option.<Boolean>createBuilder()
                                 .name(Component.translatable("text.light-overlay.config.option.show_when_paused.name"))
                                 .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.show_when_paused.description")))
-                                .binding(
-                                        true,
+                                        .binding(
+                                        showWhenPaused,
                                         () -> showWhenPaused,
                                         newVal -> showWhenPaused = newVal)
                                 .controller(TickBoxControllerBuilder::create)
                                 .build())
-                        .option(Option.<Integer>createBuilder()
+                                .option(Option.<Integer>createBuilder()
                                 .name(Component.translatable("text.light-overlay.config.option.max_computations_per_tick.name"))
                                 .description(OptionDescription.of(Component.translatable("text.light-overlay.config.option.max_computations_per_tick.description")))
                                 .binding(
-                                        32,
+                                        maxComputationsPerTick,
                                         () -> maxComputationsPerTick,
                                         newVal -> {
                                             maxComputationsPerTick = newVal;
@@ -306,7 +319,7 @@ public class ModConfig {
                                 .option(Option.<Boolean>createBuilder()
                                         .name(Component.translatable("text.light-overlay.config.option.enable_iris_flicker_fix.name"))
                                         .binding(
-                                                true,
+                                                enableIrisFlickerFix,
                                                 () -> enableIrisFlickerFix,
                                                 newVal -> enableIrisFlickerFix = newVal)
                                         .controller(TickBoxControllerBuilder::create)
@@ -314,7 +327,7 @@ public class ModConfig {
                                 .option(Option.<Integer>createBuilder()
                                         .name(Component.translatable("text.light-overlay.config.option.nearby_check_distance.name"))
                                         .binding(
-                                                16 * 16,
+                                                nearbyCheckDistanceSquared,
                                                 () -> nearbyCheckDistanceSquared,
                                                 newVal -> nearbyCheckDistanceSquared = newVal)
                                         .controller(IntegerFieldControllerBuilder::create)


### PR DESCRIPTION
fixes an issue with yacl where the default values are not initialized properly on incomplete config files.

fixes #42 
fixes #41 (probably)
fixes #40 