### PR TITLE
Fix description for light level threshold in the End

### DIFF
--- a/src/main/resources/assets/light-overlay/lang/en_us.json
+++ b/src/main/resources/assets/light-overlay/lang/en_us.json
@@ -15,7 +15,7 @@
   "text.light-overlay.config.option.light_level_threshold_nether.name": "Nether",
   "text.light-overlay.config.option.light_level_threshold_nether.description": "At what block light should the overlay turn green in the Nether? Default is 12 for spawn-proofing against (Zombified) Piglins and Blazes.\nFor Skeletons, set to 14\nFor Endermen & Wither Skeletons, set to 8",
   "text.light-overlay.config.option.light_level_threshold_end.name": "The End",
-  "text.light-overlay.config.option.light_level_threshold_end.description": "At what block light should the overlay turn green in the Nether? Default is 1 for spawn-proofing against all mobs.",
+  "text.light-overlay.config.option.light_level_threshold_end.description": "At what block light should the overlay turn green in the the End? Default is 1 for spawn-proofing against all mobs.",
   "text.light-overlay.config.group.overlay_hiding": "Show & Hide Overlay",
   "text.light-overlay.config.option.hide_green.name": "Hide Valid/Green Spots",
   "text.light-overlay.config.option.hide_green.description": "Disables rendering for spots that would normally render green",


### PR DESCRIPTION
Changed the description for light level threshold in the End to mention the End, not Nether.